### PR TITLE
Fixed redirect to youtube link when site page in iframe.

### DIFF
--- a/_source/_assets/js/main.js
+++ b/_source/_assets/js/main.js
@@ -6,9 +6,3 @@ import CalloutController from "./controllers/callout_controller"
 const application = Application.start()
 application.register("hello", HelloController)
 application.register("callout", CalloutController)
-
-// Are we in an <iframe>?
-if (window.top !== window) {
-  // 🎶 Never Gonna Give You Up 🎶
-  location.replace("https://www.youtube.com/embed/dQw4w9WgXcQ")
-}


### PR DESCRIPTION
When I use [Side|Side](https://chrome.google.com/webstore/detail/sideside/bobidkladfnoamglfgpnllbkhjlhjlfb) chrome extension to browse [Stimulus](https://stimulus.hotwired.dev/) site in page-split mode, it redirec to https://youtu.be/dQw4w9WgXcQ. This make us failed to view Stimulus site.