### PR TITLE
Add default events for input type checkbox and radio

### DIFF
--- a/_source/reference/actions.md
+++ b/_source/reference/actions.md
@@ -54,16 +54,17 @@ Stimulus lets you shorten the action descriptors for some common element/event p
 
 The full set of these shorthand pairs is as follows:
 
-Element           | Default Event
------------------ | -------------
-a                 | click
-button            | click
-details           | toggle
-form              | submit
-input             | input
-input type=submit | click
-select            | change
-textarea          | input
+Element             | Default Event
+------------------- | -------------
+a                   | click
+button              | click
+form                | submit
+input               | input
+input type=checkbox | change
+input type=radio    | change
+input type=submit   | click
+select              | change
+textarea            | input
 
 ### Global Events
 


### PR DESCRIPTION
Hi,
After this [PR](https://github.com/hotwired/stimulus/pull/355/) the default event for checkbox and radio inputs is `change` again, this information was missing in the documentation, let’s add it 🙂