### PR TITLE
Update npm package on the homepage

### DIFF
--- a/_source/_includes/hello.html
+++ b/_source/_includes/hello.html
@@ -1,5 +1,5 @@
 // hello_controller.js
-import { Controller } from "stimulus"
+import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
   static targets = [ "name", "output" ]


### PR DESCRIPTION
Since Stimulus 3, the npm package has moved from `stimulus` to `@hotwired/stimulus`, and the older one is kept as a proxy.

However, the [Stimulus homepage] has its "hello world" example using the `stimulus` package.

This Pull Request updates the homepage, including the new npm package.

[Stimulus homepage]: https://stimulus.hotwired.dev/