### PR TITLE
Change `!=` to `!==`

### DIFF
--- a/_source/handbook/05_managing_state.md
+++ b/_source/handbook/05_managing_state.md
@@ -57,7 +57,7 @@ export default class extends Controller {
 
   showCurrentSlide() {
     this.slideTargets.forEach((element, index) => {
-      element.hidden = index != this.index
+      element.hidden = index !== this.index
     })
   }
 }
@@ -166,7 +166,7 @@ export default class extends Controller {
 
   showCurrentSlide() {
     this.slideTargets.forEach((element, index) => {
-      element.hidden = index != this.indexValue
+      element.hidden = index !== this.indexValue
     })
   }
 }


### PR DESCRIPTION
Use the [strict inequality](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Strict_inequality) operator instead of the looser one that will convert operands to compare them. 

Just saw this and thought I'd share because strict equality/inequality is generally preferred and recommended.