### PR TITLE
`<string>` typo fix

### DIFF
--- a/_source/index.njk
+++ b/_source/index.njk
@@ -42,7 +42,7 @@ layout: default
   <span>Current version: <a href="{{ release.url }}">{{ release.tag_name }}</a> &mdash; released {{ release.created_at | fullDate }}</span>
 </p>
 
-<p class="landing-summary"><string>Stimulus</strong> is a JavaScript framework with modest ambitions. It doesn’t seek to take over your entire front-end—in fact, it’s not concerned with rendering HTML at all. Instead, it’s designed to augment your HTML with just enough behavior to make it shine. Stimulus pairs beautifully with <a href="https://turbo.hotwired.dev">Turbo</a> to provide a complete solution for fast, compelling applications with a minimal amount of effort.</p>
+<p class="landing-summary"><strong>Stimulus</strong> is a JavaScript framework with modest ambitions. It doesn’t seek to take over your entire front-end—in fact, it’s not concerned with rendering HTML at all. Instead, it’s designed to augment your HTML with just enough behavior to make it shine. Stimulus pairs beautifully with <a href="https://turbo.hotwired.dev">Turbo</a> to provide a complete solution for fast, compelling applications with a minimal amount of effort.</p>
 
 <div class="landing-actions">
   <a class="landing-actions__item" href="/handbook/introduction">


### PR DESCRIPTION
It appears to be a `<strong>` tag in context, but there is a typo and the tag starts with `<string>` instead of `<strong>`. Fix this typo.